### PR TITLE
fix: lexer error text

### DIFF
--- a/src/main/java/com/kingmang/lazurite/parser/impl/LexerImplementation.java
+++ b/src/main/java/com/kingmang/lazurite/parser/impl/LexerImplementation.java
@@ -409,7 +409,7 @@ public final class LexerImplementation implements ILexer {
     }
 
     private LzrException error(String text) {
-        return new LzrException("Lexer exeption","Lexer error");
+        return new LzrException("Lexer exception", text);
     }
 
     //adding keywords from the keywords array to map KEYWORDS


### PR DESCRIPTION
При ошибке в лексере не использовался передаваемый текст/сообщение об ошибке.