### PR TITLE
fix: println crash with StackOverflowError

### DIFF
--- a/src/main/java/com/kingmang/lazurite/console/output/Output.java
+++ b/src/main/java/com/kingmang/lazurite/console/output/Output.java
@@ -13,7 +13,7 @@ public interface Output {
     }
 
     default void println() {
-        println(newline());
+        print(newline());
     }
 
     default void println(String value) {


### PR DESCRIPTION
При запуске TestRunner был StackOverflowError из-за рекурсивного вызова двух разных println.