### PR TITLE
Feature/type cast extensions

### DIFF
--- a/src/main/java/com/kingmang/lazurite/core/TypesCastExt.kt
+++ b/src/main/java/com/kingmang/lazurite/core/TypesCastExt.kt
@@ -1,0 +1,47 @@
+package com.kingmang.lazurite.core
+
+import com.kingmang.lazurite.exceptions.LzrException
+import com.kingmang.lazurite.runtime.ClassInstanceValue
+import com.kingmang.lazurite.runtime.values.*
+
+fun LzrValue.asLzrNumber(lazyMessage: (() -> String)? = null): LzrNumber {
+    return asLzrType(Types.NUMBER, lazyMessage)
+}
+
+fun LzrValue.asLzrString(lazyMessage: (() -> String)? = null): LzrString {
+    return asLzrType(Types.STRING, lazyMessage)
+}
+
+fun LzrValue.asLzrArray(lazyMessage: (() -> String)? = null): LzrArray {
+    return asLzrType(Types.ARRAY, lazyMessage)
+}
+
+fun LzrValue.asLzrMap(lazyMessage: (() -> String)? = null): LzrMap {
+    return asLzrType(Types.MAP, lazyMessage)
+}
+
+fun LzrValue.asLzrFunction(lazyMessage: (() -> String)? = null): LzrFunction {
+    return asLzrType(Types.FUNCTION, lazyMessage)
+}
+
+fun LzrValue.asLzrClass(lazyMessage: (() -> String)? = null): ClassInstanceValue {
+    return asLzrType(Types.CLASS, lazyMessage)
+}
+
+inline fun <reified T : Any> LzrValue.asLzrType(targetType: Int, noinline lazyMessage: (() -> String)?): T {
+    if (isLzrType(targetType)) return this as T
+    if (lazyMessage == null) throwTypeCastException(type(), targetType)
+    throwTypeException(lazyMessage.invoke())
+}
+
+fun throwTypeCastException(origin: Int, target: Int): Nothing {
+    throwTypeCastException(Types.typeToString(origin), Types.typeToString(target))
+}
+
+fun throwTypeCastException(origin: String, target: String): Nothing {
+    throwTypeException("Cannot cast $origin to $target")
+}
+
+fun throwTypeException(message: String): Nothing {
+    throw LzrException("TypeException", message)
+}

--- a/src/main/java/com/kingmang/lazurite/core/TypesCheckExt.kt
+++ b/src/main/java/com/kingmang/lazurite/core/TypesCheckExt.kt
@@ -1,0 +1,30 @@
+package com.kingmang.lazurite.core
+
+import com.kingmang.lazurite.runtime.values.LzrValue
+
+
+fun LzrValue.isLzrNumber(): Boolean {
+    return isLzrType(Types.NUMBER)
+}
+
+fun LzrValue.isLzrString(): Boolean {
+    return isLzrType(Types.STRING)
+}
+
+fun LzrValue.isLzrArray(): Boolean {
+    return isLzrType(Types.ARRAY)
+}
+
+fun LzrValue.isLzrMap(): Boolean {
+    return isLzrType(Types.MAP)
+}
+
+fun LzrValue.isLzrFunction(): Boolean {
+    return isLzrType(Types.FUNCTION)
+}
+
+fun LzrValue.isLzrClass(): Boolean {
+    return isLzrType(Types.CLASS)
+}
+
+inline fun LzrValue.isLzrType(targetType: Int): Boolean = type() == targetType

--- a/src/main/java/com/kingmang/lazurite/core/TypesSafeCastExt.kt
+++ b/src/main/java/com/kingmang/lazurite/core/TypesSafeCastExt.kt
@@ -1,0 +1,33 @@
+package com.kingmang.lazurite.core
+
+import com.kingmang.lazurite.runtime.ClassInstanceValue
+import com.kingmang.lazurite.runtime.values.*
+
+fun LzrValue.asLzrNumberOrNull(): LzrNumber? {
+    return asLzrTypeOrNull(Types.NUMBER)
+}
+
+fun LzrValue.asLzrStringOrNull(): LzrString? {
+    return asLzrTypeOrNull(Types.STRING)
+}
+
+fun LzrValue.asLzrArrayOrNull(): LzrArray? {
+    return asLzrTypeOrNull(Types.ARRAY)
+}
+
+fun LzrValue.asLzrMapOrNull(): LzrMap? {
+    return asLzrTypeOrNull(Types.MAP)
+}
+
+fun LzrValue.asLzrFunctionOrNull(): LzrFunction? {
+    return asLzrTypeOrNull(Types.FUNCTION)
+}
+
+fun LzrValue.asLzrClassOrNull(): ClassInstanceValue? {
+    return asLzrTypeOrNull(Types.CLASS)
+}
+
+inline fun <reified T : Any> LzrValue.asLzrTypeOrNull(targetType: Int): T? {
+    if (isLzrType(targetType)) return this as T
+    return null
+}

--- a/src/main/java/com/kingmang/lazurite/utils/ValueUtils.kt
+++ b/src/main/java/com/kingmang/lazurite/utils/ValueUtils.kt
@@ -2,7 +2,8 @@ package com.kingmang.lazurite.utils
 
 import com.kingmang.lazurite.core.Function
 import com.kingmang.lazurite.core.Types
-import com.kingmang.lazurite.exceptions.LzrException
+import com.kingmang.lazurite.core.asLzrFunction
+import com.kingmang.lazurite.core.asLzrNumberOrNull
 import com.kingmang.lazurite.runtime.values.*
 import org.json.JSONArray
 import org.json.JSONException
@@ -34,14 +35,12 @@ object ValueUtils {
 
     @JvmStatic
     fun getNumber(value: LzrValue): Number {
-        if (value.type() == Types.NUMBER) return (value as LzrNumber).raw()
-        return value.asInt()
+        return value.asLzrNumberOrNull()?.raw() ?: value.asInt()
     }
 
     @JvmStatic
     fun getFloatNumber(value: LzrValue): Float {
-        if (value.type() == Types.NUMBER) return (value as LzrNumber).raw().toFloat()
-        return value.asNumber().toFloat()
+        return value.asLzrNumberOrNull()?.raw()?.toFloat() ?: value.asNumber().toFloat()
     }
 
     @JvmStatic
@@ -53,13 +52,9 @@ object ValueUtils {
 
     @JvmStatic
     fun consumeFunction(value: LzrValue, argumentNumber: Int): Function {
-        if (value.type() != Types.FUNCTION) {
-            throw LzrException(
-                "TypeException",
-                "Function expected at argument ${argumentNumber + 1}, but found ${Types.typeToString(value.type())}"
-            )
-        }
-        return (value as LzrFunction).value
+        return value.asLzrFunction {
+            "Function expected at argument ${argumentNumber + 1}, but found ${Types.typeToString(value.type())}"
+        }.value
     }
 
     fun <T : Number> collectNumberConstants(clazz: Class<*>, type: Class<T>): LzrMap {

--- a/src/test/java/core/TypesCastExtTest.kt
+++ b/src/test/java/core/TypesCastExtTest.kt
@@ -1,0 +1,105 @@
+package core
+
+import com.kingmang.lazurite.core.*
+import com.kingmang.lazurite.runtime.ClassInstanceValue
+import com.kingmang.lazurite.runtime.values.*
+import org.junit.Test
+import testutils.assertLzrTypeFails
+import kotlin.test.assertEquals
+
+class TypesCastExtTest {
+
+    private val types = listOf(
+        LzrNumber.ONE to Types.NUMBER,
+        LzrString("") to Types.STRING,
+        LzrArray(emptyList()) to Types.ARRAY,
+        LzrMap(emptyMap()) to Types.MAP,
+        LzrFunction.EMPTY to Types.FUNCTION,
+        ClassInstanceValue("Test") to Types.CLASS
+    )
+
+    private val testMessage = "Test message"
+
+    private val testLazyMessage = { testMessage }
+
+    @Test
+    fun `asNumber Expect number or fail`() {
+        assertType(Types.NUMBER) { asLzrNumber(it) }
+    }
+
+    @Test
+    fun `asString Expect string or fail`() {
+        assertType(Types.STRING) { asLzrString(it) }
+    }
+
+    @Test
+    fun `asArray Expect array or fail`() {
+        assertType(Types.ARRAY) { asLzrArray(it) }
+    }
+
+    @Test
+    fun `asMap Expect map or fail`() {
+        assertType(Types.MAP) { asLzrMap(it) }
+    }
+
+    @Test
+    fun `asFunction Expect function or fail`() {
+        assertType(Types.FUNCTION) { asLzrFunction(it) }
+    }
+
+    @Test
+    fun `asClass Expect class or fail`() {
+        assertType(Types.CLASS) { asLzrClass(it) }
+    }
+
+    @Test
+    fun `asTypeTest Expect type or fail`() {
+        types.forEach { (lzrValue, type) ->
+            assertEquals(lzrValue, lzrValue.asLzrType(type, testLazyMessage))
+        }
+    }
+
+    @Test
+    fun `throwTypeCastException with types Expect valid fail`() {
+        assertLzrTypeFails(castText("map", "string")) {
+            throwTypeCastException(Types.MAP, Types.STRING)
+        }
+        assertLzrTypeFails(castText("string", "class")) {
+            throwTypeCastException(Types.STRING, Types.CLASS)
+        }
+    }
+
+    @Test
+    fun `throwTypeCastException with strings Expect valid fail`() {
+        assertLzrTypeFails(castText("map", "string")) {
+            throwTypeCastException("map", "string")
+        }
+        assertLzrTypeFails(castText("string", "class")) {
+            throwTypeCastException("string", "class")
+        }
+    }
+
+    @Test
+    fun `throwTypeException with message Expect valid fail`() {
+        assertLzrTypeFails(testMessage) {
+            throwTypeException(testMessage)
+        }
+    }
+
+    private fun castText(origin: String, target: String): String {
+        return "Cannot cast $origin to $target"
+    }
+
+    private fun assertType(targetType: Int, block: LzrValue.((() -> String)?) -> LzrValue) {
+        types.forEach { (lzrValue, type) ->
+            val message = "valueType:${Types.typeToString(lzrValue.type())}"
+            if (type == targetType) {
+                assertEquals(lzrValue, block.invoke(lzrValue, null), message)
+            } else {
+                assertLzrTypeFails(testMessage) {
+                    block.invoke(lzrValue, testLazyMessage)
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/core/TypesCheckExtTest.kt
+++ b/src/test/java/core/TypesCheckExtTest.kt
@@ -1,0 +1,62 @@
+package core
+
+import com.kingmang.lazurite.core.*
+import com.kingmang.lazurite.runtime.ClassInstanceValue
+import com.kingmang.lazurite.runtime.values.*
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class TypesCheckExtTest {
+
+    private val types = listOf(
+        LzrNumber.ONE to Types.NUMBER,
+        LzrString("") to Types.STRING,
+        LzrArray(emptyList()) to Types.ARRAY,
+        LzrMap(emptyMap()) to Types.MAP,
+        LzrFunction.EMPTY to Types.FUNCTION,
+        ClassInstanceValue("Test") to Types.CLASS
+    )
+
+    @Test
+    fun `isNumber Expect true with number`() {
+        assertType(Types.NUMBER) { it.isLzrNumber() }
+    }
+
+    @Test
+    fun `isString Expect true with string`() {
+        assertType(Types.STRING) { it.isLzrString() }
+    }
+
+    @Test
+    fun `isArray Expect true with array`() {
+        assertType(Types.ARRAY) { it.isLzrArray() }
+    }
+
+    @Test
+    fun `isMap Expect true with map`() {
+        assertType(Types.MAP) { it.isLzrMap() }
+    }
+
+    @Test
+    fun `isFunction Expect true with function`() {
+        assertType(Types.FUNCTION) { it.isLzrFunction() }
+    }
+
+    @Test
+    fun `isClass Expect true with class`() {
+        assertType(Types.CLASS) { it.isLzrClass() }
+    }
+
+    @Test
+    fun `isType Expect true with type`() {
+        types.forEach { (lzrValue, type) ->
+            assertEquals(true, lzrValue.isLzrType(type))
+        }
+    }
+
+    private fun assertType(targetType: Int, block: (LzrValue) -> Boolean) {
+        types.forEach { (lzrValue, type) ->
+            assertEquals(type == targetType, block.invoke(lzrValue), "valueType:${Types.typeToString(lzrValue.type())}")
+        }
+    }
+}

--- a/src/test/java/core/TypesSafeCastExtTest.kt
+++ b/src/test/java/core/TypesSafeCastExtTest.kt
@@ -1,0 +1,68 @@
+package core
+
+import com.kingmang.lazurite.core.*
+import com.kingmang.lazurite.runtime.ClassInstanceValue
+import com.kingmang.lazurite.runtime.values.*
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class TypesSafeCastExtTest {
+
+    private val types = listOf(
+        LzrNumber.ONE to Types.NUMBER,
+        LzrString("") to Types.STRING,
+        LzrArray(emptyList()) to Types.ARRAY,
+        LzrMap(emptyMap()) to Types.MAP,
+        LzrFunction.EMPTY to Types.FUNCTION,
+        ClassInstanceValue("Test") to Types.CLASS
+    )
+
+    @Test
+    fun `asNumberOrNull Expect valid number`() {
+        assertType(Types.NUMBER) { it.asLzrNumberOrNull() }
+    }
+
+    @Test
+    fun `asStringOrNull Expect valid string`() {
+        assertType(Types.STRING) { it.asLzrStringOrNull() }
+    }
+
+    @Test
+    fun `asArrayOrNull Expect valid array`() {
+        assertType(Types.ARRAY) { it.asLzrArrayOrNull() }
+    }
+
+    @Test
+    fun `asMapOrNull Expect valid map`() {
+        assertType(Types.MAP) { it.asLzrMapOrNull() }
+    }
+
+    @Test
+    fun `asFunctionOrNull Expect valid function`() {
+        assertType(Types.FUNCTION) { it.asLzrFunctionOrNull() }
+    }
+
+    @Test
+    fun `asClassOrNull Expect valid class`() {
+        assertType(Types.CLASS) { it.asLzrClassOrNull() }
+    }
+
+    @Test
+    fun `asTypeOrNull Expect valid type`() {
+        types.forEach { (lzrValue, type) ->
+            assertEquals(lzrValue, lzrValue.asLzrTypeOrNull(type))
+        }
+    }
+
+    private fun assertType(targetType: Int, block: (LzrValue) -> LzrValue?) {
+        types.forEach { (lzrValue, type) ->
+            val actual = block.invoke(lzrValue)
+            val message = "valueType:${Types.typeToString(lzrValue.type())}"
+            if (type == targetType) {
+                assertEquals(lzrValue, actual, message)
+            } else {
+                assertEquals(null, actual, message)
+            }
+        }
+    }
+}

--- a/src/test/java/core/TypesTest.kt
+++ b/src/test/java/core/TypesTest.kt
@@ -1,0 +1,55 @@
+package core
+
+import com.kingmang.lazurite.core.Types
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class TypesTest {
+
+    private val names = listOf(
+        "object" to 0,
+        "number" to 1,
+        "string" to 2,
+        "array" to 3,
+        "map" to 4,
+        "function" to 5,
+        "class" to 6
+    )
+
+    private val types = listOf(
+        Types.OBJECT to 0,
+        Types.NUMBER to 1,
+        Types.STRING to 2,
+        Types.ARRAY to 3,
+        Types.MAP to 4,
+        Types.FUNCTION to 5,
+        Types.CLASS to 6,
+    )
+
+    @Test
+    fun `check type constants Expect valid values`() {
+        types.forEach { (actual, expected) ->
+            assertEquals(expected, actual)
+        }
+    }
+
+    @Test
+    fun `getNames Expect equals names`() {
+        val expected = names.map { it.first }
+        val actual = Types.NAMES.toList()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `typeToString with known types Expect names`() {
+        names.forEach { (name, type) ->
+            assertEquals(name, Types.typeToString(type), "type:$type")
+        }
+    }
+
+    @Test
+    fun `typeToString with unknown type Expect unknown name`() {
+        val type = 100101
+        assertEquals("unknown ($type)", Types.typeToString(type), "type:$type")
+    }
+}


### PR DESCRIPTION
Добавил экстеншены на проверку и кастинг Lzr* типов.
Поможет в дальнейшем рефактиринге избаваиться однотипной проверки типов и т.д.

1. Функции isLzr*() - просто проверка типа
2. Функции asLzr*OrNull() - пытается скастить класс к нужному типу, в случае неудачи вернёт null
3. Функции asLzr*() - пытается скастить класс к нужному типу, в случае неудачи кинет исключение. Так-же можно передать лямбду с кастомным сообщением об ошибке.
