### PR TITLE
fix: find scope naming

### DIFF
--- a/src/main/java/com/kingmang/lazurite/runtime/Libraries.kt
+++ b/src/main/java/com/kingmang/lazurite/runtime/Libraries.kt
@@ -1,7 +1,7 @@
 package com.kingmang.lazurite.runtime
 
 import com.kingmang.lazurite.runtime.scope.Scope
-import com.kingmang.lazurite.runtime.scope.findOrRoot
+import com.kingmang.lazurite.runtime.scope.findOrCurrent
 
 private typealias LibraryList = MutableList<String>
 
@@ -49,7 +49,7 @@ object Libraries {
         findScope(path).scope.data.remove(path)
     }
 
-    private fun findScope(path: String) = scope.findOrRoot {
+    private fun findScope(path: String) = scope.findOrCurrent {
         it.data.contains(path)
     }
 

--- a/src/main/java/com/kingmang/lazurite/runtime/Variables.kt
+++ b/src/main/java/com/kingmang/lazurite/runtime/Variables.kt
@@ -1,7 +1,7 @@
 package com.kingmang.lazurite.runtime
 
 import com.kingmang.lazurite.runtime.scope.Scope
-import com.kingmang.lazurite.runtime.scope.findOrRoot
+import com.kingmang.lazurite.runtime.scope.findOrCurrent
 import com.kingmang.lazurite.runtime.values.LzrNumber
 import com.kingmang.lazurite.runtime.values.LzrValue
 import kotlin.concurrent.Volatile
@@ -71,7 +71,7 @@ object Variables {
         findScope(key).scope.data.remove(key)
     }
 
-    private fun findScope(variable: String) = scope.findOrRoot {
+    private fun findScope(variable: String) = scope.findOrCurrent {
         it.data.containsKey(variable)
     }
 

--- a/src/main/java/com/kingmang/lazurite/runtime/scope/ScopeExt.kt
+++ b/src/main/java/com/kingmang/lazurite/runtime/scope/ScopeExt.kt
@@ -1,6 +1,6 @@
 package com.kingmang.lazurite.runtime.scope
 
-inline fun <T> Scope<T>.findOrRoot(condition: (Scope<T>) -> Boolean): ScopeFindData<T> {
+inline fun <T> Scope<T>.findOrCurrent(condition: (Scope<T>) -> Boolean): ScopeFindData<T> {
     var current = this
 
     do {

--- a/src/test/java/runtime/scope/ScopeTest.kt
+++ b/src/test/java/runtime/scope/ScopeTest.kt
@@ -1,7 +1,7 @@
 package runtime.scope
 
 import com.kingmang.lazurite.runtime.scope.Scope
-import com.kingmang.lazurite.runtime.scope.findOrRoot
+import com.kingmang.lazurite.runtime.scope.findOrCurrent
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -14,7 +14,7 @@ class ScopeTest {
     @Test
     fun `find in empty root Expect root and notfound`() {
         val root = Scope(null, setOf<String>())
-        val result = root.findOrRoot { it.data.contains(DATA) }
+        val result = root.findOrCurrent { it.data.contains(DATA) }
         assertEquals(root, result.scope)
         assertEquals(false, result.isFound)
     }
@@ -22,7 +22,7 @@ class ScopeTest {
     @Test
     fun `find in filled root Expect root and found`() {
         val root = Scope(null, setOf(DATA))
-        val result = root.findOrRoot { it.data.contains(DATA) }
+        val result = root.findOrCurrent { it.data.contains(DATA) }
         assertEquals(root, result.scope)
         assertEquals(true, result.isFound)
     }
@@ -31,7 +31,7 @@ class ScopeTest {
     fun `find in empty root and empty child Expect child and notfound`() {
         val root = Scope(null, setOf<String>())
         val child = Scope(root, setOf())
-        val result = child.findOrRoot { it.data.contains(DATA) }
+        val result = child.findOrCurrent { it.data.contains(DATA) }
         assertEquals(child, result.scope)
         assertEquals(false, result.isFound)
     }
@@ -40,7 +40,7 @@ class ScopeTest {
     fun `find in empty root and filled child Expect child and found`() {
         val root = Scope(null, setOf<String>())
         val child = Scope(root, setOf(DATA))
-        val result = child.findOrRoot { it.data.contains(DATA) }
+        val result = child.findOrCurrent { it.data.contains(DATA) }
         assertEquals(child, result.scope)
         assertEquals(true, result.isFound)
     }
@@ -49,7 +49,7 @@ class ScopeTest {
     fun `find in filled root and empty child Expect root and found`() {
         val root = Scope(null, setOf(DATA))
         val child = Scope(root, setOf())
-        val result = child.findOrRoot { it.data.contains(DATA) }
+        val result = child.findOrCurrent { it.data.contains(DATA) }
         assertEquals(root, result.scope)
         assertEquals(true, result.isFound)
     }
@@ -58,7 +58,7 @@ class ScopeTest {
     fun `find in filled root and filled child Expect child and found`() {
         val root = Scope(null, setOf(DATA))
         val child = Scope(root, setOf(DATA))
-        val result = child.findOrRoot { it.data.contains(DATA) }
+        val result = child.findOrCurrent { it.data.contains(DATA) }
         assertEquals(child, result.scope)
         assertEquals(true, result.isFound)
     }


### PR DESCRIPTION
findOrRoot неправильно описывала поведение функции. 
Если ничего подходящего не найдено, то возвращается текущий Scope, а не рутовый.